### PR TITLE
fix: harden v3.2.2 release readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,27 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
 
       - name: Build, test, and publish net48 single-executable release
         shell: pwsh
-        run: ./build/Publish-NanoPic.ps1 -Configuration Release -RuntimeIdentifier win-x64
+        run: |
+          New-Item -ItemType Directory -Force -Path artifacts/test-reports | Out-Null
+          $env:NANOPIC_REPORT_DIR = (Resolve-Path artifacts/test-reports).Path
+          ./build/Publish-NanoPic.ps1 -Configuration Release -RuntimeIdentifier win-x64
+
+      - name: Audit NuGet vulnerabilities
+        shell: pwsh
+        run: |
+          $report = dotnet list NanoPic.sln package --vulnerable --include-transitive --format json --no-restore | Out-String
+          if ($LASTEXITCODE -ne 0) { throw 'NuGet vulnerability audit failed to run.' }
+          Set-Content -LiteralPath artifacts/test-reports/nuget-vulnerabilities.json -Value $report -Encoding utf8
+          if ($report -match '"vulnerabilities"\s*:') { throw 'NuGet vulnerability audit found one or more vulnerable packages.' }
 
       - name: Verify publish layout and size gate
         shell: pwsh
@@ -34,6 +45,7 @@ jobs:
             'artifacts/publish/win-x64/NanoPic.exe.sha256',
             'artifacts/publish/win-x64/THIRD-PARTY-NOTICES.txt',
             'artifacts/publish/win-x64/licenses/BSD-3-CLAUSE-LIBWEBP.txt',
+            'artifacts/publish/win-x64/licenses/MIT-MANAGED-DEPENDENCIES.txt',
             'artifacts/publish/win-x64/licenses/README.md',
             'artifacts/publish/win-x64/SBOM.spdx.json',
             'artifacts/publish/win-x64/manifest.json'
@@ -53,14 +65,22 @@ jobs:
           if ($manifest.primaryArtifact.sha256 -ne $actual) { throw 'Manifest hash does not match NanoPic.exe.' }
           $sbom = Get-Content 'artifacts/publish/win-x64/SBOM.spdx.json' -Raw | ConvertFrom-Json
           if ('libwebp' -notin @($sbom.packages.name)) { throw 'SBOM does not contain libwebp.' }
+          if ('System.Text.Json' -notin @($sbom.packages.name)) { throw 'SBOM does not contain managed runtime dependencies.' }
           $forbidden = @(Get-ChildItem 'artifacts/publish/win-x64' -File | Where-Object {
             $_.Extension -in @('.dll', '.pdb', '.config') -or $_.Name -match 'Magick|ImageMagick'
           })
           if ($forbidden.Count -ne 0) { throw "Forbidden runtime files: $($forbidden.Name -join ', ')" }
 
       - name: Upload release audit bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: NanoPic-win-x64
           path: artifacts/publish/win-x64
+          if-no-files-found: error
+
+      - name: Upload test and security reports
+        uses: actions/upload-artifact@v7
+        with:
+          name: NanoPic-test-reports
+          path: artifacts/test-reports
           if-no-files-found: error

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
     <MagickNetPackageVersion>14.16.0</MagickNetPackageVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Costura.Fody" Version="5.7.0" />
-    <PackageVersion Include="Fody" Version="6.8.2" />
+    <PackageVersion Include="Costura.Fody" Version="6.2.0" />
+    <PackageVersion Include="Fody" Version="6.9.3" />
     <PackageVersion Include="Magick.NET-Q8-x64" Version="$(MagickNetPackageVersion)" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -1,96 +1,45 @@
-NanoPic Third-Party Notices
-===========================
+NanoPic 3.2.2 — Third-Party Notices
+====================================
 
-This project distributes and/or uses the following third-party components.
+NanoPic distributes third-party code inside its single executable. The full
+license texts referenced below are included in the release `licenses` folder.
 
-1. FreeImage
-------------
+libwebp 1.6.0
+-------------
+Copyright (c) 2010, Google Inc. All rights reserved.
+License: BSD 3-Clause License.
+Project: https://chromium.googlesource.com/webm/libwebp
 
-Component:
-- FreeImage.dll
-- FreeImageNET 3.17.1 (managed wrapper package)
+NanoPic embeds the official Windows x64 cwebp and dwebp tools. The complete
+license text is distributed as BSD-3-CLAUSE-LIBWEBP.txt.
 
-Observed local binary version:
-- FreeImage.dll file version: 3.18.0.0
+Costura.Fody 6.2.0
+------------------
+License: MIT License.
+Project: https://github.com/Fody/Costura
 
-Used by:
-- PNG encoding fallback/quantization path in NanoPic
-- See NanoPic/Program/Logic/Compress/PngEncoder.cs
+Costura weaves NanoPic's managed runtime dependencies into NanoPic.exe and
+provides the embedded assembly loader. The MIT license is distributed as
+MIT-MANAGED-DEPENDENCIES.txt.
 
-Official project:
-- https://freeimage.sourceforge.io/
+Microsoft managed runtime libraries
+-----------------------------------
+License: MIT License.
+Project: https://github.com/dotnet/runtime
 
-Official licensing page:
-- https://freeimage.sourceforge.io/license.html
+- Microsoft.Bcl.AsyncInterfaces 8.0.0
+- System.Buffers 4.5.1
+- System.Memory 4.5.5
+- System.Numerics.Vectors 4.5.0
+- System.Runtime.CompilerServices.Unsafe 6.0.0
+- System.Text.Encodings.Web 8.0.0
+- System.Text.Json 8.0.5
+- System.Threading.Tasks.Extensions 4.5.4
+- System.ValueTuple 4.5.0
 
-License model:
-- Dual-licensed by the FreeImage project under GPLv2/GPLv3 or the FreeImage Public License (FIPL).
-- For commercial or closed-source distribution, the FreeImage project explicitly points users to the FIPL option.
+The complete MIT license is distributed as MIT-MANAGED-DEPENDENCIES.txt.
 
-Compliance notes from the official licensing page:
-- Distribute the license text you choose with the application.
-- Provide a suitable acknowledgement in the program's About box or the user documentation.
-
-Suggested acknowledgement text from the FreeImage project:
-- "This software uses the FreeImage open source image library. See http://freeimage.sourceforge.net for details."
-
-Repository note:
-- See licenses/FreeImage-NOTICE.txt for the current NanoPic-specific usage summary.
-- See licenses/FreeImage-FIPL-1.0.txt for the bundled FIPL text.
-
-
-2. libwebp
-----------
-
-Component:
-- libwebp.dll
-- PicLibrary/Resource/libwebp.lib
-- PicLibrary/Resource/libwebpdemux.lib
-- PicLibrary/Resource/libwebpmux.lib
-
-Observed local runtime version:
-- libwebp decoder version reported by the bundled DLL: 0.4.1
-
-Used by:
-- WebP encode/decode interop in NanoPic
-- See NanoPic/Program/FileIO/DLL_WEBP_Decode.cs
-- See NanoPic/Program/FileIO/DLL_WEBP_Encode.cs
-
-Official project:
-- https://chromium.googlesource.com/webm/libwebp
-- https://github.com/webmproject/libwebp
-
-Official licensing page:
-- https://www.webmproject.org/license/software/
-
-Additional IP rights grant:
-- https://www.webmproject.org/license/additional/
-
-License model:
-- The WebM Project software license (BSD-3-Clause style) plus the WebM additional IP rights grant.
-
-Compliance notes from the official project pages:
-- Redistribution in source and binary form requires preserving the copyright notice,
-  license conditions, and disclaimer in documentation and/or other accompanying materials.
-- The WebM project also publishes an additional patent grant with a defensive termination clause.
-
-Repository note:
-- See licenses/libwebp-NOTICE.txt for the current NanoPic-specific usage summary.
-- See licenses/libwebp-COPYING.txt for the bundled libwebp software license text.
-- See licenses/WebM-Additional-IP-Rights.txt for the bundled WebM patent grant text.
-
-
-3. Distribution guidance for NanoPic releases
----------------------------------------------
-
-For binary releases of NanoPic, include at minimum:
-- this THIRD-PARTY-NOTICES.txt file
-- licenses/FreeImage-NOTICE.txt
-- licenses/libwebp-NOTICE.txt
-- licenses/FreeImage-FIPL-1.0.txt
-- licenses/libwebp-COPYING.txt
-- licenses/WebM-Additional-IP-Rights.txt
-
-Recommended:
-- add a Third-Party Notices or Licenses entry in the application About dialog
-- mention that NanoPic uses FreeImage and libwebp in release notes or README
+Windows Imaging Component and .NET Framework 4.8
+------------------------------------------------
+Windows Imaging Component (WIC) and .NET Framework 4.8 are Windows system
+components and are not redistributed as separate NanoPic release files.

--- a/build/Publish-NanoPic.ps1
+++ b/build/Publish-NanoPic.ps1
@@ -137,6 +137,7 @@ try {
             'NanoPic.exe.sha256',
             'THIRD-PARTY-NOTICES.txt',
             'licenses/BSD-3-CLAUSE-LIBWEBP.txt',
+            'licenses/MIT-MANAGED-DEPENDENCIES.txt',
             'licenses/README.md',
             'SBOM.spdx.json',
             'manifest.json'
@@ -173,6 +174,7 @@ try {
         'NanoPic.exe.sha256',
         'THIRD-PARTY-NOTICES.txt',
         'licenses/BSD-3-CLAUSE-LIBWEBP.txt',
+        'licenses/MIT-MANAGED-DEPENDENCIES.txt',
         'licenses/README.md',
         'SBOM.spdx.json',
         'manifest.json'

--- a/build/release-assets/SBOM.spdx.template.json
+++ b/build/release-assets/SBOM.spdx.template.json
@@ -32,9 +32,129 @@
       "licenseDeclared": "BSD-3-Clause",
       "copyrightText": "Copyright (c) 2010, Google Inc.",
       "primaryPackagePurpose": "LIBRARY"
+    },
+    {
+      "name": "Costura.Fody",
+      "SPDXID": "SPDXRef-Package-Costura-Fody",
+      "versionInfo": "6.2.0",
+      "downloadLocation": "https://www.nuget.org/packages/Costura.Fody/6.2.0",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "primaryPackagePurpose": "LIBRARY"
+    },
+    {
+      "name": "Microsoft.Bcl.AsyncInterfaces",
+      "SPDXID": "SPDXRef-Package-Microsoft-Bcl-AsyncInterfaces",
+      "versionInfo": "8.0.0",
+      "downloadLocation": "https://www.nuget.org/packages/Microsoft.Bcl.AsyncInterfaces/8.0.0",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "Copyright (c) .NET Foundation and Contributors",
+      "primaryPackagePurpose": "LIBRARY"
+    },
+    {
+      "name": "System.Buffers",
+      "SPDXID": "SPDXRef-Package-System-Buffers",
+      "versionInfo": "4.5.1",
+      "downloadLocation": "https://www.nuget.org/packages/System.Buffers/4.5.1",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "Copyright (c) .NET Foundation and Contributors",
+      "primaryPackagePurpose": "LIBRARY"
+    },
+    {
+      "name": "System.Memory",
+      "SPDXID": "SPDXRef-Package-System-Memory",
+      "versionInfo": "4.5.5",
+      "downloadLocation": "https://www.nuget.org/packages/System.Memory/4.5.5",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "Copyright (c) .NET Foundation and Contributors",
+      "primaryPackagePurpose": "LIBRARY"
+    },
+    {
+      "name": "System.Numerics.Vectors",
+      "SPDXID": "SPDXRef-Package-System-Numerics-Vectors",
+      "versionInfo": "4.5.0",
+      "downloadLocation": "https://www.nuget.org/packages/System.Numerics.Vectors/4.5.0",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "Copyright (c) .NET Foundation and Contributors",
+      "primaryPackagePurpose": "LIBRARY"
+    },
+    {
+      "name": "System.Runtime.CompilerServices.Unsafe",
+      "SPDXID": "SPDXRef-Package-System-Runtime-CompilerServices-Unsafe",
+      "versionInfo": "6.0.0",
+      "downloadLocation": "https://www.nuget.org/packages/System.Runtime.CompilerServices.Unsafe/6.0.0",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "Copyright (c) .NET Foundation and Contributors",
+      "primaryPackagePurpose": "LIBRARY"
+    },
+    {
+      "name": "System.Text.Encodings.Web",
+      "SPDXID": "SPDXRef-Package-System-Text-Encodings-Web",
+      "versionInfo": "8.0.0",
+      "downloadLocation": "https://www.nuget.org/packages/System.Text.Encodings.Web/8.0.0",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "Copyright (c) .NET Foundation and Contributors",
+      "primaryPackagePurpose": "LIBRARY"
+    },
+    {
+      "name": "System.Text.Json",
+      "SPDXID": "SPDXRef-Package-System-Text-Json",
+      "versionInfo": "8.0.5",
+      "downloadLocation": "https://www.nuget.org/packages/System.Text.Json/8.0.5",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "Copyright (c) .NET Foundation and Contributors",
+      "primaryPackagePurpose": "LIBRARY"
+    },
+    {
+      "name": "System.Threading.Tasks.Extensions",
+      "SPDXID": "SPDXRef-Package-System-Threading-Tasks-Extensions",
+      "versionInfo": "4.5.4",
+      "downloadLocation": "https://www.nuget.org/packages/System.Threading.Tasks.Extensions/4.5.4",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "Copyright (c) .NET Foundation and Contributors",
+      "primaryPackagePurpose": "LIBRARY"
+    },
+    {
+      "name": "System.ValueTuple",
+      "SPDXID": "SPDXRef-Package-System-ValueTuple",
+      "versionInfo": "4.5.0",
+      "downloadLocation": "https://www.nuget.org/packages/System.ValueTuple/4.5.0",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "Copyright (c) .NET Foundation and Contributors",
+      "primaryPackagePurpose": "LIBRARY"
     }
   ],
   "relationships": [
-    {"spdxElementId": "SPDXRef-Package-NanoPic", "relationshipType": "DEPENDS_ON", "relatedSpdxElement": "SPDXRef-Package-libwebp"}
+    {"spdxElementId": "SPDXRef-Package-NanoPic", "relationshipType": "DEPENDS_ON", "relatedSpdxElement": "SPDXRef-Package-libwebp"},
+    {"spdxElementId": "SPDXRef-Package-NanoPic", "relationshipType": "DEPENDS_ON", "relatedSpdxElement": "SPDXRef-Package-Costura-Fody"},
+    {"spdxElementId": "SPDXRef-Package-NanoPic", "relationshipType": "DEPENDS_ON", "relatedSpdxElement": "SPDXRef-Package-Microsoft-Bcl-AsyncInterfaces"},
+    {"spdxElementId": "SPDXRef-Package-NanoPic", "relationshipType": "DEPENDS_ON", "relatedSpdxElement": "SPDXRef-Package-System-Buffers"},
+    {"spdxElementId": "SPDXRef-Package-NanoPic", "relationshipType": "DEPENDS_ON", "relatedSpdxElement": "SPDXRef-Package-System-Memory"},
+    {"spdxElementId": "SPDXRef-Package-NanoPic", "relationshipType": "DEPENDS_ON", "relatedSpdxElement": "SPDXRef-Package-System-Numerics-Vectors"},
+    {"spdxElementId": "SPDXRef-Package-NanoPic", "relationshipType": "DEPENDS_ON", "relatedSpdxElement": "SPDXRef-Package-System-Runtime-CompilerServices-Unsafe"},
+    {"spdxElementId": "SPDXRef-Package-NanoPic", "relationshipType": "DEPENDS_ON", "relatedSpdxElement": "SPDXRef-Package-System-Text-Encodings-Web"},
+    {"spdxElementId": "SPDXRef-Package-NanoPic", "relationshipType": "DEPENDS_ON", "relatedSpdxElement": "SPDXRef-Package-System-Text-Json"},
+    {"spdxElementId": "SPDXRef-Package-NanoPic", "relationshipType": "DEPENDS_ON", "relatedSpdxElement": "SPDXRef-Package-System-Threading-Tasks-Extensions"},
+    {"spdxElementId": "SPDXRef-Package-NanoPic", "relationshipType": "DEPENDS_ON", "relatedSpdxElement": "SPDXRef-Package-System-ValueTuple"}
   ]
 }

--- a/build/release-assets/licenses/MIT-MANAGED-DEPENDENCIES.txt
+++ b/build/release-assets/licenses/MIT-MANAGED-DEPENDENCIES.txt
@@ -1,0 +1,23 @@
+MIT License
+
+This license applies to Costura.Fody and the Microsoft managed runtime
+libraries identified in the accompanying THIRD-PARTY-NOTICES.txt and SBOM.
+Copyright notices are retained by their respective authors and contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/build/release-assets/licenses/README.md
+++ b/build/release-assets/licenses/README.md
@@ -1,13 +1,11 @@
-# NanoPic 发布许可证目录
+# NanoPic 3.2.2 发布许可证目录
 
-此目录与发布根目录的 `THIRD-PARTY-NOTICES.txt`、`SBOM.spdx.json` 一起构成 NanoPic 3.0.0-preview.1 的第三方组件许可证记录。
+此目录与发布根目录的 `THIRD-PARTY-NOTICES.txt`、`SBOM.spdx.json` 一起构成 NanoPic 3.2.2 的第三方组件许可证记录。
 
 | 组件 | 版本 | 许可证 | 对应文件 |
 |---|---:|---|---|
 | libwebp（官方 Windows x64 `cwebp` / `dwebp`） | 1.6.0 | BSD-3-Clause | `BSD-3-CLAUSE-LIBWEBP.txt` |
+| Costura.Fody（嵌入式程序集加载器） | 6.2.0 | MIT | `MIT-MANAGED-DEPENDENCIES.txt` |
+| Microsoft 管理运行时库 | 见 `THIRD-PARTY-NOTICES.txt` / SBOM | MIT | `MIT-MANAGED-DEPENDENCIES.txt` |
 
 运行时可执行文件为单一 `NanoPic.exe`。Windows Imaging Component 与 .NET Framework 4.8 是 Windows 系统组件，不随 NanoPic 重复分发。本目录仅提供许可证与审计材料，不是运行 NanoPic 所需的额外二进制依赖。
-
-## 参考
-
-[1]: https://github.com/webmproject/libwebp/blob/v1.6.0/COPYING "libwebp 1.6.0 license"

--- a/src/NanoPic.App/THIRD-PARTY-NOTICES.txt
+++ b/src/NanoPic.App/THIRD-PARTY-NOTICES.txt
@@ -1,5 +1,8 @@
-NanoPic 3.0 — Third-Party Notices
-===================================
+NanoPic 3.2.2 — Third-Party Notices
+====================================
+
+NanoPic distributes third-party code inside its single executable. The full
+license texts referenced below are included in the release `licenses` folder.
 
 libwebp 1.6.0
 -------------
@@ -8,8 +11,35 @@ License: BSD 3-Clause License.
 Project: https://chromium.googlesource.com/webm/libwebp
 
 NanoPic embeds the official Windows x64 cwebp and dwebp tools. The complete
-license text is distributed as BSD-3-CLAUSE-LIBWEBP.txt with release audit
-materials.
+license text is distributed as BSD-3-CLAUSE-LIBWEBP.txt.
 
+Costura.Fody 6.2.0
+------------------
+License: MIT License.
+Project: https://github.com/Fody/Costura
+
+Costura weaves NanoPic's managed runtime dependencies into NanoPic.exe and
+provides the embedded assembly loader. The MIT license is distributed as
+MIT-MANAGED-DEPENDENCIES.txt.
+
+Microsoft managed runtime libraries
+-----------------------------------
+License: MIT License.
+Project: https://github.com/dotnet/runtime
+
+- Microsoft.Bcl.AsyncInterfaces 8.0.0
+- System.Buffers 4.5.1
+- System.Memory 4.5.5
+- System.Numerics.Vectors 4.5.0
+- System.Runtime.CompilerServices.Unsafe 6.0.0
+- System.Text.Encodings.Web 8.0.0
+- System.Text.Json 8.0.5
+- System.Threading.Tasks.Extensions 4.5.4
+- System.ValueTuple 4.5.0
+
+The complete MIT license is distributed as MIT-MANAGED-DEPENDENCIES.txt.
+
+Windows Imaging Component and .NET Framework 4.8
+------------------------------------------------
 Windows Imaging Component (WIC) and .NET Framework 4.8 are Windows system
-components and are not redistributed in the NanoPic executable.
+components and are not redistributed as separate NanoPic release files.

--- a/src/NanoPic.App/packages.lock.json
+++ b/src/NanoPic.App/packages.lock.json
@@ -4,19 +4,18 @@
     ".NETFramework,Version=v4.8": {
       "Costura.Fody": {
         "type": "Direct",
-        "requested": "[5.7.0, )",
-        "resolved": "5.7.0",
-        "contentHash": "MmL28WOOnJEBWORXj6bfSxfWaZW8gWSXEJTdrjB9AQi4COX6RXr2xdGL9HsxpWwn6f5Io0NmNuwFJe94w1YmQA==",
+        "requested": "[6.2.0, )",
+        "resolved": "6.2.0",
+        "contentHash": "jaX+A6sw6pI7lkLDTvxN7zU8Ja/a50N2xPKF6RYy0J6QF62wVg+hJMXJph2K8XarDaAlxQ82EaKv3fAvUNyRpg==",
         "dependencies": {
-          "Fody": "6.5.5",
-          "NETStandard.Library": "1.6.1"
+          "Fody": "6.9.3"
         }
       },
       "Fody": {
         "type": "Direct",
-        "requested": "[6.8.2, )",
-        "resolved": "6.8.2",
-        "contentHash": "sjGHrtGS1+kcrv99WXCvujOFBTQp4zCH3ZC9wo2LAtVaJkuLpHghQx3y4k1Q8ZKuDAbEw+HE6ZjPUJQK3ejepQ=="
+        "requested": "[6.9.3, )",
+        "resolved": "6.9.3",
+        "contentHash": "1CUGgFdyECDKgi5HaUBhdv6k+VG9Iy4OCforGfHyar3xQXAJypZkzymgKtWj/4SPd6nSG0Qi7NH71qHrDSZLaA=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
         "type": "Direct",
@@ -35,164 +34,15 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Microsoft.NETCore.Platforms": {
-        "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
-      },
       "Microsoft.NETFramework.ReferenceAssemblies.net48": {
         "type": "Transitive",
         "resolved": "1.0.3",
         "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
       },
-      "Microsoft.Win32.Primitives": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "9ZQKCWxH7Ijp9BfahvL2Zyf1cJIk8XYLF6Yjzr2yi0b2cOut/HQ31qf1ThHAgCc3WiZMdnWcfJCgN82/0UunxA=="
-      },
-      "NETStandard.Library": {
-        "type": "Transitive",
-        "resolved": "1.6.1",
-        "contentHash": "WcSp3+vP+yHNgS8EV5J7pZ9IRpeDuARBPN28by8zqff1wJQXm26PVU8L3/fYLBJVU7BtDyqNVWq2KlCVvSSR4A==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.Win32.Primitives": "4.3.0",
-          "System.AppContext": "4.3.0",
-          "System.Collections": "4.3.0",
-          "System.Collections.Concurrent": "4.3.0",
-          "System.Console": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Diagnostics.Tools": "4.3.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Globalization.Calendars": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.IO.Compression": "4.3.0",
-          "System.IO.Compression.ZipFile": "4.3.0",
-          "System.IO.FileSystem": "4.3.0",
-          "System.IO.FileSystem.Primitives": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.Net.Http": "4.3.0",
-          "System.Net.Primitives": "4.3.0",
-          "System.Net.Sockets": "4.3.0",
-          "System.ObjectModel": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.Handles": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Runtime.InteropServices.RuntimeInformation": "4.3.0",
-          "System.Runtime.Numerics": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "System.Text.Encoding.Extensions": "4.3.0",
-          "System.Text.RegularExpressions": "4.3.0",
-          "System.Threading": "4.3.0",
-          "System.Threading.Tasks": "4.3.0",
-          "System.Threading.Timer": "4.3.0",
-          "System.Xml.ReaderWriter": "4.3.0",
-          "System.Xml.XDocument": "4.3.0"
-        }
-      },
-      "System.AppContext": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "fKC+rmaLfeIzUhagxY17Q9siv/sPrjjKcfNg1Ic8IlQkZLipo8ljcaZQu4VtI4Jqbzjc2VTjzGLF6WmsRXAEgA=="
-      },
       "System.Buffers": {
         "type": "Transitive",
         "resolved": "4.5.1",
         "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
-      },
-      "System.Collections": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "3Dcj85/TBdVpL5Zr+gEEBUuFe2icOnLalmEh9hfck1PTYbbyWuZgh4fmm2ysCLTrqLQw6t3TgTyJ+VLp+Qb+Lw=="
-      },
-      "System.Collections.Concurrent": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "ztl69Xp0Y/UXCL+3v3tEU+lIy+bvjKNUmopn1wep/a291pVPK7dxBd6T7WnlQqRog+d1a/hSsgRsmFnIBKTPLQ=="
-      },
-      "System.Console": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "DHDrIxiqk1h03m6khKWV2X8p/uvN79rgSqpilL6uzpmSfxfU5ng8VcPtW4qsDsQDHiTv6IPV9TmD5M/vElPNLg=="
-      },
-      "System.Diagnostics.Debug": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "ZUhUOdqmaG5Jk3Xdb8xi5kIyQYAA4PnTNlHx1mu9ZY3qv4ELIdKbnL/akbGaKi2RnNUWaZsAs31rvzFdewTj2g=="
-      },
-      "System.Diagnostics.DiagnosticSource": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "tD6kosZnTAGdrEa0tZSuFyunMbt/5KYDnHdndJYGqZoNy00XVXyACd5d6KnE1YgYv3ne2CjtAfNXo/fwEhnKUA=="
-      },
-      "System.Diagnostics.Tools": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "UUvkJfSYJMM6x527dJg2VyWPSRqIVB0Z7dbjHst1zmwTXz5CcXSYJFWRpuigfbO1Lf7yfZiIaEUesfnl/g5EyA=="
-      },
-      "System.Diagnostics.Tracing": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "rswfv0f/Cqkh78rA5S8eN8Neocz234+emGCtTF3lxPY96F+mmmUen6tbn0glN6PMvlKQb9bPAY5e9u7fgPTkKw=="
-      },
-      "System.Globalization": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "kYdVd2f2PAdFGblzFswE4hkNANJBKRmsfa2X5LG2AcWE1c7/4t0pYae1L8vfZ5xvE2nK/R9JprtToA61OSHWIg=="
-      },
-      "System.Globalization.Calendars": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "GUlBtdOWT4LTV3I+9/PJW+56AnnChTaOqqTLFtdmype/L500M2LIyXgmtd9X2P2VOkmJd5c67H5SaC2QcL1bFA=="
-      },
-      "System.IO": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "3qjaHvxQPDpSOYICjUoTsmoq5u6QJAFRUITgeT/4gqkF1bajbSmb1kwSxEA8AHlofqgcKJcM8udgieRNhaJ5Cg=="
-      },
-      "System.IO.Compression": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "YHndyoiV90iu4iKG115ibkhrG+S3jBm8Ap9OwoUAzO5oPDAWcr0SFwQFm0HjM8WkEZWo0zvLTyLmbvTkW1bXgg=="
-      },
-      "System.IO.Compression.ZipFile": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "G4HwjEsgIwy3JFBduZ9quBkAu+eUwjIdJleuNSgmUojbH6O3mlvEIme+GHx/cLlTAPcrnnL7GqvB9pTlWRfhOg=="
-      },
-      "System.IO.FileSystem": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "3wEMARTnuio+ulnvi+hkRNROYwa1kylvYahhcLk4HSoVdl+xxTFVeVlYOfLwrDPImGls0mDqbMhrza8qnWPTdA==",
-        "dependencies": {
-          "System.IO.FileSystem.Primitives": "4.3.0"
-        }
-      },
-      "System.IO.FileSystem.Primitives": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "6QOb2XFLch7bEc4lIcJH49nJN2HV+OC3fHDgsLVsBVBk3Y4hFAnOBGzJ2lUu7CyDDFo9IBWkSsnbkT6IBwwiMw=="
-      },
-      "System.Linq": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "5DbqIUpsDp0dFftytzuMmc0oeMdQwjcP/EWxsksIz/w1TcFRkZ3yKKz0PqiYFMmEwPSWw+qNVqD7PJ889JzHbw=="
-      },
-      "System.Linq.Expressions": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "PGKkrd2khG4CnlyJwxwwaWWiSiWFNBGlgXvJpeO0xCXrZ89ODrQ6tjEWS/kOqZ8GwEOUATtKtzp1eRgmYNfclg=="
       },
       "System.Memory": {
         "type": "Transitive",
@@ -204,132 +54,15 @@
           "System.Runtime.CompilerServices.Unsafe": "4.5.3"
         }
       },
-      "System.Net.Http": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "sYg+FtILtRQuYWSIAuNOELwVuVsxVyJGWQyOnlAzhV4xvhyFnON1bAzYYC+jjRW8JREM45R0R5Dgi8MTC5sEwA==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "4.3.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.0"
-        }
-      },
-      "System.Net.Primitives": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "qOu+hDwFwoZPbzPvwut2qATe3ygjeQBDQj91xlsaqGFQUI5i4ZnZb8yyQuLGpDGivEPIt8EJkd1BVzVoP31FXA=="
-      },
-      "System.Net.Sockets": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "m6icV6TqQOAdgt5N/9I5KNpjom/5NFtkmGseEH+AK/hny8XrytLH3+b5M8zL/Ycg3fhIocFpUMyl/wpFnVRvdw=="
-      },
       "System.Numerics.Vectors": {
         "type": "Transitive",
         "resolved": "4.5.0",
         "contentHash": "QQTlPTl06J/iiDbJCiepZ4H//BVraReU4O4EoRw1U02H5TLUIT7xn3GnDp9AXPSlJUDyFs4uWjWafNX6WrAojQ=="
       },
-      "System.ObjectModel": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "bdX+80eKv9bN6K4N+d77OankKHGn6CH711a6fcOpMQu2Fckp/Ft4L/kW9WznHpyR0NRAvJutzOMHNNlBGvxQzQ=="
-      },
-      "System.Reflection": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "KMiAFoW7MfJGa9nDFNcfu+FpEdiHpWgTcS2HdMpDvt9saK3y/G4GwprPyzqjFH9NTaGPQeWNHU+iDlDILj96aQ=="
-      },
-      "System.Reflection.Extensions": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "rJkrJD3kBI5B712aRu4DpSIiHRtr6QlfZSQsb0hYHrDCZORXCFjQfoipo2LaMUHoT9i1B7j7MnfaEKWDFmFQNQ=="
-      },
-      "System.Reflection.Primitives": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "5RXItQz5As4xN2/YUDxdpsEkMhvw3e6aNveFXUn4Hl/udNTCNhnKp8lT9fnc3MhvGKh1baak5CovpuQUXHAlIA=="
-      },
-      "System.Resources.ResourceManager": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "/zrcPkkWdZmI4F92gL/TPumP98AVDu/Wxr3CSJGQQ+XN6wbRZcyfSKVoPo17ilb3iOr0cCRqJInGwNMolqhS8A=="
-      },
-      "System.Runtime": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "JufQi0vPQ0xGnAczR13AUFglDyVYt4Kqnz1AZaiKZ5+GICq0/1MH/mO/eAJHt/mHW1zjKBJd7kV26SrxddAhiw=="
-      },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
-      },
-      "System.Runtime.Extensions": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "guW0uK0fn5fcJJ1tJVXYd7/1h5F+pea1r7FLSOz/f8vPEqbR2ZAknuRDvTQ8PzAilDveOxNjSfr0CHfIQfFk8g=="
-      },
-      "System.Runtime.Handles": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "OKiSUN7DmTWeYb3l51A7EYaeNMnvxwE249YtZz7yooT4gOZhmTjIn48KgSsw2k2lYdLgTKNJw/ZIfSElwDRVgg=="
-      },
-      "System.Runtime.InteropServices": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "uv1ynXqiMK8mp1GM3jDqPCFN66eJ5w5XNomaK2XD+TuCroNTLFGeZ+WCmBMcBDyTFKou3P6cR6J/QsaqDp7fGQ==",
-        "dependencies": {
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Runtime.InteropServices.RuntimeInformation": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "cbz4YJMqRDR7oLeMRbdYv7mYzc++17lNhScCX0goO2XpGWdvAt60CGN+FHdePUEHCe/Jy9jUlvNAiNdM+7jsOw=="
-      },
-      "System.Runtime.Numerics": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "yMH+MfdzHjy17l2KESnPiF2dwq7T+xLnSJar7slyimAkUh/gTrS9/UQOtv7xarskJ2/XDSNvfLGOBQPjL7PaHQ=="
-      },
-      "System.Security.Cryptography.Algorithms": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "W1kd2Y8mYSCgc3ULTAZ0hOP2dSdG5YauTb1089T0/kRcN2MpSAW1izOFROrJgxSlMn3ArsgHXagigyi+ibhevg==",
-        "dependencies": {
-          "System.IO": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0"
-        }
-      },
-      "System.Security.Cryptography.Encoding": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "1DEWjZZly9ae9C79vFwqaO5kaOlI5q+3/55ohmq/7dpDyDfc8lYe7YVxJUZ5MF/NtbkRjwFRo14yM4OEo9EmDw=="
-      },
-      "System.Security.Cryptography.Primitives": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "7bDIyVFNL/xKeFHjhobUAQqSpJq9YTOpbEs6mR233Et01STBMXNAc/V+BM6dwYGc95gVh/Zf+iVXWzj3mE8DWg=="
-      },
-      "System.Security.Cryptography.X509Certificates": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "t2Tmu6Y2NtJ2um0RtcuhP7ZdNNxXEgUm2JeoA/0NvlMjAhKCnM1NX07TDl3244mVp3QU6LPEhT3HTtH1uF7IYw==",
-        "dependencies": {
-          "System.Security.Cryptography.Algorithms": "4.3.0",
-          "System.Security.Cryptography.Encoding": "4.3.0"
-        }
-      },
-      "System.Text.Encoding": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "BiIg+KWaSDOITze6jGQynxg64naAPtqGHBwDrLaCtixsa5bKiR8dpPOHA7ge3C0JJQizJE+sfkz1wV+BAKAYZw=="
-      },
-      "System.Text.Encoding.Extensions": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "YVMK0Bt/A43RmwizJoZ22ei2nmrhobgeiYwFzC4YAN+nue8RF6djXDMog0UCn+brerQoYVyaS+ghy9P/MUVcmw=="
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
@@ -341,21 +74,6 @@
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
-      "System.Text.RegularExpressions": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "RpT2DA+L660cBt1FssIE9CAGpLFdFPuheB7pLpKpn6ZXNby7jDERe8Ua/Ne2xGiwLVG2JOqziiaVCGDon5sKFA=="
-      },
-      "System.Threading": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "VkUS0kOBcUf3Wwm0TSbrevDDZ6BlM+b/HRiapRFWjM5O0NS0LviG0glKmFK+hhPDd1XFeSdU1GmlLhb2CoVpIw=="
-      },
-      "System.Threading.Tasks": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "LbSxKEdOUhVe8BezB/9uOGGppt+nZf6e1VFyw6v3DN6lqitm0OSn2uXMOdtP0M3W4iMcqcivm2J6UgqiwwnXiA=="
-      },
       "System.Threading.Tasks.Extensions": {
         "type": "Transitive",
         "resolved": "4.5.4",
@@ -364,30 +82,15 @@
           "System.Runtime.CompilerServices.Unsafe": "4.5.3"
         }
       },
-      "System.Threading.Timer": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "Z6YfyYTCg7lOZjJzBjONJTFKGN9/NIYKSxhU5GRd+DTwHSZyvWp1xuI5aR+dLg+ayyC5Xv57KiY4oJ0tMO89fQ=="
-      },
       "System.ValueTuple": {
         "type": "Transitive",
         "resolved": "4.5.0",
         "contentHash": "okurQJO6NRE/apDIP23ajJ0hpiNmJ+f0BwOlB/cSqTLQlw5upkf+5+96+iG2Jw40G1fCVCyPz/FhIABUjMR+RQ=="
       },
-      "System.Xml.ReaderWriter": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "GrprA+Z0RUXaR4N7/eW71j1rgMnEnEVlgii49GZyAjTH7uliMnrOU3HNFBr6fEDBCJCIdlVNq9hHbaDR621XBA=="
-      },
-      "System.Xml.XDocument": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "5zJ0XDxAIg8iy+t4aMnQAu0MqVbqyvfoUVl1yDV61xdo3Vth45oA2FoY4pPkxYAH5f8ixpmTqXeEIya95x0aCQ=="
-      },
       "nanopic.codecs": {
         "type": "Project",
         "dependencies": {
-          "NanoPic.Core": "[3.0.0-preview.1, )"
+          "NanoPic.Core": "[3.2.2, )"
         }
       },
       "nanopic.core": {
@@ -396,7 +99,7 @@
       "nanopic.infrastructure": {
         "type": "Project",
         "dependencies": {
-          "NanoPic.Core": "[3.0.0-preview.1, )",
+          "NanoPic.Core": "[3.2.2, )",
           "System.Text.Json": "[8.0.5, )"
         }
       },
@@ -416,51 +119,6 @@
         }
       }
     },
-    ".NETFramework,Version=v4.8/win-x64": {
-      "System.IO.Compression": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "YHndyoiV90iu4iKG115ibkhrG+S3jBm8Ap9OwoUAzO5oPDAWcr0SFwQFm0HjM8WkEZWo0zvLTyLmbvTkW1bXgg=="
-      },
-      "System.Net.Http": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "sYg+FtILtRQuYWSIAuNOELwVuVsxVyJGWQyOnlAzhV4xvhyFnON1bAzYYC+jjRW8JREM45R0R5Dgi8MTC5sEwA==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "4.3.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.0"
-        }
-      },
-      "System.Runtime.InteropServices.RuntimeInformation": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "cbz4YJMqRDR7oLeMRbdYv7mYzc++17lNhScCX0goO2XpGWdvAt60CGN+FHdePUEHCe/Jy9jUlvNAiNdM+7jsOw=="
-      },
-      "System.Security.Cryptography.Algorithms": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "W1kd2Y8mYSCgc3ULTAZ0hOP2dSdG5YauTb1089T0/kRcN2MpSAW1izOFROrJgxSlMn3ArsgHXagigyi+ibhevg==",
-        "dependencies": {
-          "System.IO": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0"
-        }
-      },
-      "System.Security.Cryptography.Encoding": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "1DEWjZZly9ae9C79vFwqaO5kaOlI5q+3/55ohmq/7dpDyDfc8lYe7YVxJUZ5MF/NtbkRjwFRo14yM4OEo9EmDw=="
-      },
-      "System.Security.Cryptography.X509Certificates": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "t2Tmu6Y2NtJ2um0RtcuhP7ZdNNxXEgUm2JeoA/0NvlMjAhKCnM1NX07TDl3244mVp3QU6LPEhT3HTtH1uF7IYw==",
-        "dependencies": {
-          "System.Security.Cryptography.Algorithms": "4.3.0",
-          "System.Security.Cryptography.Encoding": "4.3.0"
-        }
-      }
-    }
+    ".NETFramework,Version=v4.8/win-x64": {}
   }
 }

--- a/src/NanoPic.Codecs/PngQuantizer.cs
+++ b/src/NanoPic.Codecs/PngQuantizer.cs
@@ -115,8 +115,10 @@ public static class PngQuantizer
                 exactColors[packed] = 1;
             }
 
-            // 如果已经确认不是少色图且 quality 明显需要量化，可以在超过 2048 种颜色时提前停止精确统计
-            if (exactColors.Count > 2048 && quality < 100)
+            // Indexed8 最多只能无损表达 256 种颜色。发现第 257 种颜色后，
+            // 无论 Quality 为何都停止增长唯一颜色字典，避免照片级大图产生
+            // 与唯一颜色数线性增长的内存占用。
+            if (exactColors.Count > 256)
             {
                 break;
             }
@@ -199,7 +201,7 @@ public static class PngQuantizer
             pixelBuffer,
             totalBytes,
             targetColors,
-            hasTransparentPixel,
+            ref hasTransparentPixel,
             cancellationToken);
 
         cancellationToken.ThrowIfCancellationRequested();
@@ -258,7 +260,7 @@ public static class PngQuantizer
         byte[] pixelBuffer,
         int totalBytes,
         int maxColors,
-        bool hasTransparentPixel,
+        ref bool hasTransparentPixel,
         CancellationToken cancellationToken)
     {
         // 5-5-5-4 降采样桶 (A:4-bit, R:5-bit, G:5-bit, B:5-bit = 19-bit index -> 524288 slots)
@@ -272,6 +274,13 @@ public static class PngQuantizer
             var g = pixelBuffer[offset + 1];
             var r = pixelBuffer[offset + 2];
             var a = pixelBuffer[offset + 3];
+
+            if (a < 255)
+            {
+                // 精确颜色扫描会在第 257 种颜色后提前结束，因此完整直方图
+                // 扫描必须继续发现透明与半透明像素。
+                hasTransparentPixel = true;
+            }
 
             if (a < 16)
             {
@@ -437,10 +446,14 @@ public static class PngQuantizer
         {
             Start = start,
             End = end,
-            MinR = 255, MaxR = 0,
-            MinG = 255, MaxG = 0,
-            MinB = 255, MaxB = 0,
-            MinA = 255, MaxA = 0
+            MinR = 255,
+            MaxR = 0,
+            MinG = 255,
+            MaxG = 0,
+            MinB = 255,
+            MaxB = 0,
+            MinA = 255,
+            MaxA = 0
         };
 
         var count = 0;

--- a/src/NanoPic.Codecs/PngTargetSizeSearch.cs
+++ b/src/NanoPic.Codecs/PngTargetSizeSearch.cs
@@ -36,11 +36,26 @@ public static class PngTargetSizeSearch
         Func<IReadOnlyList<BitmapFrame>, ImageResizeOptions, IReadOnlyList<BitmapFrame>> resizeRunner,
         CancellationToken cancellationToken)
     {
+        if (targetOptions is null) throw new ArgumentNullException(nameof(targetOptions));
+
         if (initialFrames == null || initialFrames.Count == 0)
         {
             return ImageOperationResult<PngTargetSearchResult>.Failed(
                 ImageFailureKind.InvalidConfiguration,
                 "没有可用于搜索目标大小的图像帧。");
+        }
+
+        if (encodeRunner is null) throw new ArgumentNullException(nameof(encodeRunner));
+        if (resizeRunner is null) throw new ArgumentNullException(nameof(resizeRunner));
+
+        if (targetOptions.TargetBytes <= 0 ||
+            targetOptions.MinQuality is < 1 or > 100 ||
+            targetOptions.MaxQuality is < 1 or > 100 ||
+            targetOptions.MinQuality > targetOptions.MaxQuality)
+        {
+            return ImageOperationResult<PngTargetSearchResult>.Failed(
+                ImageFailureKind.InvalidConfiguration,
+                "PNG 目标大小或质量范围无效。");
         }
 
         var currentFrames = initialFrames;
@@ -60,39 +75,29 @@ public static class PngTargetSizeSearch
             var evaluated = new Dictionary<int, long>();
             var candidates = new List<PngTargetCandidate>();
 
-            // 1. 评估预设梯度
-            foreach (var q in InitialCandidateQualities)
+            // 1. 评估预设梯度，并始终包含用户指定的 Min/Max 边界。
+            var initialQualities = new SortedSet<int>(Comparer<int>.Create(
+                (left, right) => right.CompareTo(left)))
             {
-                if (q < targetOptions.MinQuality || q > targetOptions.MaxQuality)
+                targetOptions.MinQuality,
+                targetOptions.MaxQuality
+            };
+            foreach (var quality in InitialCandidateQualities)
+            {
+                if (quality >= targetOptions.MinQuality && quality <= targetOptions.MaxQuality)
                 {
-                    continue;
+                    initialQualities.Add(quality);
                 }
+            }
 
+            foreach (var q in initialQualities)
+            {
                 cancellationToken.ThrowIfCancellationRequested();
                 if (!evaluated.ContainsKey(q))
                 {
                     var bytes = await encodeRunner(currentFrames, temporaryOutputPath, q, cancellationToken).ConfigureAwait(false);
                     evaluated[q] = bytes;
                     candidates.Add(new PngTargetCandidate(q, bytes, q < 100));
-                }
-            }
-
-            if (candidates.Count == 0)
-            {
-                // 若范围外，至少测一次 MinQuality 与 MaxQuality
-                var minQ = Math.Max(1, Math.Min(100, targetOptions.MinQuality));
-                var maxQ = Math.Max(1, Math.Min(100, targetOptions.MaxQuality));
-                if (!evaluated.ContainsKey(maxQ))
-                {
-                    var bytes = await encodeRunner(currentFrames, temporaryOutputPath, maxQ, cancellationToken).ConfigureAwait(false);
-                    evaluated[maxQ] = bytes;
-                    candidates.Add(new PngTargetCandidate(maxQ, bytes, maxQ < 100));
-                }
-                if (!evaluated.ContainsKey(minQ))
-                {
-                    var bytes = await encodeRunner(currentFrames, temporaryOutputPath, minQ, cancellationToken).ConfigureAwait(false);
-                    evaluated[minQ] = bytes;
-                    candidates.Add(new PngTargetCandidate(minQ, bytes, minQ < 100));
                 }
             }
 
@@ -103,28 +108,45 @@ public static class PngTargetSizeSearch
                 // 找出初步满足条件的最高 Quality
                 var bestCandidate = matchingCandidates.OrderByDescending(c => c.Quality).First();
 
-                // 尝试在 bestCandidate.Quality 和更高一层未达标的 Quality 之间做 1-2 步局部细化
+                // 在最佳候选和最近的更高失败候选之间逐级细化，避免一次
+                // 中点采样遗漏更高的可达 Quality。
                 var higherFailing = candidates
                     .Where(c => c.Quality > bestCandidate.Quality && c.Bytes > targetOptions.TargetBytes)
                     .OrderBy(c => c.Quality)
                     .FirstOrDefault();
 
-                if (higherFailing != null && higherFailing.Quality - bestCandidate.Quality > 3)
+                if (higherFailing != null)
                 {
-                    var midQ = (bestCandidate.Quality + higherFailing.Quality) / 2;
-                    if (!evaluated.ContainsKey(midQ))
+                    for (var refinedQuality = higherFailing.Quality - 1;
+                         refinedQuality > bestCandidate.Quality;
+                         refinedQuality--)
                     {
-                        var midBytes = await encodeRunner(currentFrames, temporaryOutputPath, midQ, cancellationToken).ConfigureAwait(false);
-                        evaluated[midQ] = midBytes;
-                        if (midBytes <= targetOptions.TargetBytes)
+                        cancellationToken.ThrowIfCancellationRequested();
+                        if (evaluated.ContainsKey(refinedQuality))
                         {
-                            bestCandidate = new PngTargetCandidate(midQ, midBytes, midQ < 100);
+                            continue;
+                        }
+
+                        var refinedBytes = await encodeRunner(
+                            currentFrames,
+                            temporaryOutputPath,
+                            refinedQuality,
+                            cancellationToken).ConfigureAwait(false);
+                        evaluated[refinedQuality] = refinedBytes;
+                        candidates.Add(new PngTargetCandidate(
+                            refinedQuality,
+                            refinedBytes,
+                            refinedQuality < 100));
+                        if (refinedBytes <= targetOptions.TargetBytes)
+                        {
+                            bestCandidate = new PngTargetCandidate(
+                                refinedQuality,
+                                refinedBytes,
+                                refinedQuality < 100);
+                            break;
                         }
                     }
                 }
-
-                // 重新写出选定的最优质量产物
-                await encodeRunner(currentFrames, temporaryOutputPath, bestCandidate.Quality, cancellationToken).ConfigureAwait(false);
 
                 string? notice = null;
                 if (resized)
@@ -152,7 +174,6 @@ public static class PngTargetSizeSearch
                 if (targetOptions.AllowExceed)
                 {
                     // 允许超出：输出原尺寸最小体积候选
-                    await encodeRunner(currentFrames, temporaryOutputPath, smallestCandidate.Quality, cancellationToken).ConfigureAwait(false);
                     return ImageOperationResult<PngTargetSearchResult>.Success(new PngTargetSearchResult(
                         smallestCandidate,
                         TargetReached: false,
@@ -182,7 +203,6 @@ public static class PngTargetSizeSearch
                 // 已经缩至极限无法再缩
                 if (targetOptions.AllowExceed)
                 {
-                    await encodeRunner(currentFrames, temporaryOutputPath, smallestCandidate.Quality, cancellationToken).ConfigureAwait(false);
                     return ImageOperationResult<PngTargetSearchResult>.Success(new PngTargetSearchResult(
                         smallestCandidate,
                         TargetReached: false,

--- a/src/NanoPic.Codecs/WicImageCodec.cs
+++ b/src/NanoPic.Codecs/WicImageCodec.cs
@@ -16,6 +16,12 @@ namespace NanoPic.Codecs;
 
 public sealed class WicImageCodec : IImageCodec
 {
+    private sealed record FramePreparationResult(
+        IReadOnlyList<BitmapFrame> Frames,
+        bool PixelsChanged,
+        bool MetadataChanged,
+        bool OrientationChanged);
+
     private static readonly IReadOnlyCollection<ImageFormat> Formats = new HashSet<ImageFormat>
     {
         ImageFormat.Jpeg,
@@ -220,7 +226,12 @@ public sealed class WicImageCodec : IImageCodec
                     return new ImageOperationResult<ImageEncodedOutput>(default, safetyFailure);
                 }
 
-                var outputFrames = PrepareFrames(sourceFrames, request.SourceFormat, request.OutputFormat, request.Transform);
+                var preparation = PrepareFrames(
+                    sourceFrames,
+                    request.SourceFormat,
+                    request.OutputFormat,
+                    request.Transform);
+                var outputFrames = preparation.Frames;
                 var outputMetadata = CreateMetadata(outputFrames, request.OutputFormat, sourceBytes: 0L);
                 var outputSafetyFailure = ImageSafetyValidator.Validate(outputMetadata, request.SafetyLimits);
                 if (outputSafetyFailure is not null)
@@ -233,52 +244,107 @@ public sealed class WicImageCodec : IImageCodec
                 var exceededTarget = false;
                 var targetSizeResized = false;
                 string? targetSizeNotice = null;
+                var outputAlreadyWritten = false;
+                var canReusePngSource = CanReuseSourceFile(request, preparation);
 
                 if (request.Encoding.TargetSize is { } targetSize)
                 {
+                    if (request.OutputFormat == ImageFormat.Png && canReusePngSource)
+                    {
+                        var sourceFileBytes = new FileInfo(request.SourcePath).Length;
+                        if (sourceFileBytes > 0 && sourceFileBytes <= targetSize.TargetBytes)
+                        {
+                            File.Copy(request.SourcePath, request.TemporaryOutputPath, overwrite: true);
+                            return ImageOperationResult<ImageEncodedOutput>.Success(
+                                new ImageEncodedOutput(
+                                    outputMetadata with { SourceBytes = sourceFileBytes },
+                                    Quality: 100,
+                                    Bytes: sourceFileBytes,
+                                    TargetSizeReached: true,
+                                    ExceededTarget: false));
+                        }
+                    }
+
                     if (request.OutputFormat == ImageFormat.Png)
                     {
-                        var pngSearch = await PngTargetSizeSearch.SearchAsync(
-                            outputFrames,
-                            request.TemporaryOutputPath,
-                            targetSize,
-                            (frames, path, q, token) =>
-                            {
-                                token.ThrowIfCancellationRequested();
-                                WritePng(frames, path, q, token);
-                                return Task.FromResult(new FileInfo(path).Length);
-                            },
-                            (frames, resizeOptions) =>
-                            {
-                                var newFrames = new List<BitmapFrame>(frames.Count);
-                                foreach (var frame in frames)
-                                {
-                                    var resizedSource = Resize(frame, resizeOptions);
-                                    var newFrame = BitmapFrame.Create(
-                                        resizedSource,
-                                        null,
-                                        frame.Metadata as BitmapMetadata,
-                                        null);
-                                    newFrame.Freeze();
-                                    newFrames.Add(newFrame);
-                                }
-                                return newFrames;
-                            },
-                            cancellationToken).ConfigureAwait(false);
-
-                        if (!pngSearch.IsSuccess || pngSearch.Value is null)
+                        var candidatePaths = new Dictionary<string, string>(StringComparer.Ordinal);
+                        try
                         {
-                            return new ImageOperationResult<ImageEncodedOutput>(default, pngSearch.Failure);
-                        }
+                            var pngSearch = await PngTargetSizeSearch.SearchAsync(
+                                outputFrames,
+                                request.TemporaryOutputPath,
+                                targetSize,
+                                (frames, _, q, token) =>
+                                {
+                                    token.ThrowIfCancellationRequested();
+                                    var key = CreatePngCandidateKey(frames, q);
+                                    if (candidatePaths.TryGetValue(key, out var cachedPath))
+                                    {
+                                        return Task.FromResult(new FileInfo(cachedPath).Length);
+                                    }
 
-                        var result = pngSearch.Value;
-                        effectiveQuality = result.Selected.Quality;
-                        targetReached = result.TargetReached;
-                        exceededTarget = result.ExceededTarget;
-                        targetSizeResized = result.Resized;
-                        targetSizeNotice = result.Notice;
-                        outputFrames = result.FinalFrames;
-                        outputMetadata = CreateMetadata(outputFrames, request.OutputFormat, sourceBytes: 0L);
+                                    var candidatePath = CreateTemporaryPath("png-candidate", ".png");
+                                    try
+                                    {
+                                        WritePng(frames, candidatePath, q, token);
+                                        candidatePaths.Add(key, candidatePath);
+                                        return Task.FromResult(new FileInfo(candidatePath).Length);
+                                    }
+                                    catch
+                                    {
+                                        DeleteIfExists(candidatePath);
+                                        throw;
+                                    }
+                                },
+                                (frames, resizeOptions) =>
+                                {
+                                    var newFrames = new List<BitmapFrame>(frames.Count);
+                                    foreach (var frame in frames)
+                                    {
+                                        var resizedSource = Resize(frame, resizeOptions);
+                                        var newFrame = BitmapFrame.Create(
+                                            resizedSource,
+                                            null,
+                                            frame.Metadata as BitmapMetadata,
+                                            null);
+                                        newFrame.Freeze();
+                                        newFrames.Add(newFrame);
+                                    }
+                                    return newFrames;
+                                },
+                                cancellationToken).ConfigureAwait(false);
+
+                            if (!pngSearch.IsSuccess || pngSearch.Value is null)
+                            {
+                                return new ImageOperationResult<ImageEncodedOutput>(default, pngSearch.Failure);
+                            }
+
+                            var result = pngSearch.Value;
+                            var selectedKey = CreatePngCandidateKey(result.FinalFrames, result.Selected.Quality);
+                            if (!candidatePaths.TryGetValue(selectedKey, out var selectedPath))
+                            {
+                                return ImageOperationResult<ImageEncodedOutput>.Failed(
+                                    ImageFailureKind.OutputVerificationFailed,
+                                    "PNG 目标大小搜索缺少选中候选产物。");
+                            }
+
+                            File.Copy(selectedPath, request.TemporaryOutputPath, overwrite: true);
+                            effectiveQuality = result.Selected.Quality;
+                            targetReached = result.TargetReached;
+                            exceededTarget = result.ExceededTarget;
+                            targetSizeResized = result.Resized;
+                            targetSizeNotice = result.Notice;
+                            outputFrames = result.FinalFrames;
+                            outputMetadata = CreateMetadata(outputFrames, request.OutputFormat, sourceBytes: 0L);
+                            outputAlreadyWritten = true;
+                        }
+                        finally
+                        {
+                            foreach (var candidatePath in candidatePaths.Values)
+                            {
+                                DeleteIfExists(candidatePath);
+                            }
+                        }
                     }
                     else
                     {
@@ -350,9 +416,9 @@ public sealed class WicImageCodec : IImageCodec
                                         var resizedSource = Resize(frame, adaptiveResize);
                                         var newFrame = BitmapFrame.Create(
                                             resizedSource,
-                                            frame.Thumbnail,
+                                            null,
                                             frame.Metadata as BitmapMetadata,
-                                            frame.ColorContexts);
+                                            null);
                                         newFrame.Freeze();
                                         newFrames.Add(newFrame);
                                     }
@@ -402,9 +468,9 @@ public sealed class WicImageCodec : IImageCodec
                                         var resizedSource = Resize(frame, adaptiveResize);
                                         var newFrame = BitmapFrame.Create(
                                             resizedSource,
-                                            frame.Thumbnail,
+                                            null,
                                             frame.Metadata as BitmapMetadata,
-                                            frame.ColorContexts);
+                                            null);
                                         newFrame.Freeze();
                                         newFrames.Add(newFrame);
                                     }
@@ -476,9 +542,9 @@ public sealed class WicImageCodec : IImageCodec
                                     var resizedSource = Resize(frame, adaptiveResize);
                                     var newFrame = BitmapFrame.Create(
                                         resizedSource,
-                                        frame.Thumbnail,
+                                        null,
                                         frame.Metadata as BitmapMetadata,
-                                        frame.ColorContexts);
+                                        null);
                                     newFrame.Freeze();
                                     newFrames.Add(newFrame);
                                 }
@@ -503,7 +569,10 @@ public sealed class WicImageCodec : IImageCodec
                     }
                 }
 
-                Write(outputFrames, request.TemporaryOutputPath, request.OutputFormat, effectiveQuality, cancellationToken);
+                if (!outputAlreadyWritten)
+                {
+                    Write(outputFrames, request.TemporaryOutputPath, request.OutputFormat, effectiveQuality, cancellationToken);
+                }
                 var bytes = new FileInfo(request.TemporaryOutputPath).Length;
                 if (bytes <= 0)
                 {
@@ -513,13 +582,18 @@ public sealed class WicImageCodec : IImageCodec
                 }
 
                 // skip-if-larger: 纯 no-op 重编码若变大则保留源文件
-                if (CanReuseSourceFile(request))
+                if (canReusePngSource)
                 {
                     var sourceFileBytes = new FileInfo(request.SourcePath).Length;
                     if (bytes >= sourceFileBytes && sourceFileBytes > 0)
                     {
                         File.Copy(request.SourcePath, request.TemporaryOutputPath, overwrite: true);
                         bytes = sourceFileBytes;
+                        if (request.Encoding.TargetSize is { } finalTarget)
+                        {
+                            targetReached = sourceFileBytes <= finalTarget.TargetBytes;
+                            exceededTarget = !targetReached;
+                        }
                     }
                 }
 
@@ -578,7 +652,7 @@ public sealed class WicImageCodec : IImageCodec
     public static bool SupportsQualitySearch(ImageFormat format) =>
         format is ImageFormat.Jpeg or ImageFormat.Webp or ImageFormat.Png;
 
-    private static IReadOnlyList<BitmapFrame> PrepareFrames(
+    private static FramePreparationResult PrepareFrames(
         IReadOnlyList<BitmapFrame> sourceFrames,
         ImageFormat sourceFormat,
         ImageFormat outputFormat,
@@ -586,6 +660,10 @@ public sealed class WicImageCodec : IImageCodec
     {
         var frameCount = outputFormat is ImageFormat.Gif or ImageFormat.Tiff ? sourceFrames.Count : 1;
         var result = new List<BitmapFrame>(frameCount);
+        var anyPixelsChanged = false;
+        var anyOrientationChanged = false;
+        var anyMetadataChanged = transform.StripMetadata ||
+            transform.MetadataNote is { Enabled: true } note && !string.IsNullOrWhiteSpace(note.Text);
         for (var index = 0; index < frameCount; index++)
         {
             var source = sourceFrames[index];
@@ -596,6 +674,7 @@ public sealed class WicImageCodec : IImageCodec
             {
                 prepared = ApplyExifOrientation(prepared, out orientationChanged);
                 pixelsChanged |= orientationChanged;
+                anyOrientationChanged |= orientationChanged;
             }
 
             if (transform.Resize is { Enabled: true } resize)
@@ -638,15 +717,22 @@ public sealed class WicImageCodec : IImageCodec
                 preserveMetadata && !pixelsChanged ? source.ColorContexts : null);
             frame.Freeze();
             result.Add(frame);
+            anyPixelsChanged |= pixelsChanged;
         }
 
+        IReadOnlyList<BitmapFrame> finalFrames = result;
         if (outputFormat == ImageFormat.Ico)
         {
             var bestFrame = result.OrderByDescending(f => (long)f.PixelWidth * f.PixelHeight).FirstOrDefault() ?? result[0];
-            return PngIcoEncoder.CreateFrames(bestFrame);
+            finalFrames = PngIcoEncoder.CreateFrames(bestFrame);
         }
 
-        return result;
+        anyMetadataChanged |= anyOrientationChanged;
+        return new FramePreparationResult(
+            finalFrames,
+            anyPixelsChanged,
+            anyMetadataChanged,
+            anyOrientationChanged);
     }
 
     private static BitmapMetadata? ApplyMetadataNote(
@@ -1076,21 +1162,16 @@ public sealed class WicImageCodec : IImageCodec
     private static bool SupportsAlpha(ImageFormat format) =>
         format is ImageFormat.Png or ImageFormat.Webp or ImageFormat.Gif or ImageFormat.Ico;
 
-    private static bool CanReuseSourceFile(ImageEncodeRequest request)
+    private static bool CanReuseSourceFile(
+        ImageEncodeRequest request,
+        FramePreparationResult preparation)
     {
         if (request.SourceFormat != ImageFormat.Png || request.OutputFormat != ImageFormat.Png)
         {
             return false;
         }
 
-        if (request.Transform.Resize is { Enabled: true }) return false;
-        if (request.Transform.BrightnessPercent != 100) return false;
-        if (request.Transform.Watermark is { Enabled: true } wm && !string.IsNullOrWhiteSpace(wm.Text)) return false;
-        if (request.Transform.Background is { FlattenTransparency: true }) return false;
-        if (request.Transform.StripMetadata) return false;
-        if (request.Transform.MetadataNote is { Enabled: true } note && !string.IsNullOrWhiteSpace(note.Text)) return false;
-
-        return true;
+        return !preparation.PixelsChanged && !preparation.MetadataChanged;
     }
 
     private static void Write(
@@ -1187,6 +1268,16 @@ public sealed class WicImageCodec : IImageCodec
         encoder.Save(output);
         output.Flush(flushToDisk: true);
     }
+
+    private static string CreatePngCandidateKey(
+        IReadOnlyList<BitmapFrame> frames,
+        int quality) =>
+        quality.ToString(CultureInfo.InvariantCulture) + ":" +
+        string.Join(
+            "|",
+            frames.Select(frame =>
+                frame.PixelWidth.ToString(CultureInfo.InvariantCulture) + "x" +
+                frame.PixelHeight.ToString(CultureInfo.InvariantCulture)));
 
     private static string CreateTemporaryPath(string purpose, string extension)
     {

--- a/tests/NanoPic.App.Tests/packages.lock.json
+++ b/tests/NanoPic.App.Tests/packages.lock.json
@@ -170,15 +170,15 @@
       "NanoPic": {
         "type": "Project",
         "dependencies": {
-          "NanoPic.Codecs": "[3.0.0-preview.1, )",
-          "NanoPic.Core": "[3.0.0-preview.1, )",
-          "NanoPic.Infrastructure": "[3.0.0-preview.1, )"
+          "NanoPic.Codecs": "[3.2.2, )",
+          "NanoPic.Core": "[3.2.2, )",
+          "NanoPic.Infrastructure": "[3.2.2, )"
         }
       },
       "nanopic.codecs": {
         "type": "Project",
         "dependencies": {
-          "NanoPic.Core": "[3.0.0-preview.1, )"
+          "NanoPic.Core": "[3.2.2, )"
         }
       },
       "nanopic.core": {
@@ -187,7 +187,7 @@
       "nanopic.infrastructure": {
         "type": "Project",
         "dependencies": {
-          "NanoPic.Core": "[3.0.0-preview.1, )",
+          "NanoPic.Core": "[3.2.2, )",
           "System.Text.Json": "[8.0.5, )"
         }
       },

--- a/tests/NanoPic.Codecs.Tests/PngCompressionTests.cs
+++ b/tests/NanoPic.Codecs.Tests/PngCompressionTests.cs
@@ -90,7 +90,10 @@ public sealed class PngCompressionTests
             var codec = new WicImageCodec();
             var req = new ImageEncodeRequest(
                 sourcePath, outPath, ImageFormat.Png, ImageFormat.Png,
-                new ImageTransformOptions(),
+                // SettingsFormMapper always supplies this background option. It is
+                // semantically inactive for PNG and must not disable source reuse.
+                new ImageTransformOptions(
+                    Background: new ImageBackgroundOptions(true, "#FFFFFF")),
                 new ImageEncodingOptions(ImageOutputFormat.Png, Quality: 100),
                 ImageSafetyLimits.Default);
 
@@ -101,6 +104,48 @@ public sealed class PngCompressionTests
             using var dstImg = new MagickImage(outPath);
             Assert.Equal(srcImg.Width, dstImg.Width);
             Assert.Equal(srcImg.Height, dstImg.Height);
+            Assert.Equal(0d, srcImg.Compare(dstImg, ErrorMetric.Absolute));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public async Task C3b_TargetSize_AlreadySatisfied_Reuses_Source_Png()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "nanopic-png-source-target-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var sourcePath = Path.Combine(AppContext.BaseDirectory, "assets", "transparent.png");
+            Assert.True(File.Exists(sourcePath), $"Missing test asset: {sourcePath}");
+            var sourceBytes = new FileInfo(sourcePath).Length;
+            var outPath = Path.Combine(tempDir, "already-satisfied.png");
+
+            var codec = new WicImageCodec();
+            var req = new ImageEncodeRequest(
+                sourcePath, outPath, ImageFormat.Png, ImageFormat.Png,
+                new ImageTransformOptions(
+                    Background: new ImageBackgroundOptions(true, "#FFFFFF")),
+                new ImageEncodingOptions(
+                    ImageOutputFormat.Png,
+                    Quality: 80,
+                    TargetSize: new TargetSizeOptions(
+                        TargetBytes: sourceBytes,
+                        AllowExceed: false,
+                        AllowResizeForTarget: false)),
+                ImageSafetyLimits.Default);
+
+            var result = await codec.TransformAndEncodeAsync(req, CancellationToken.None);
+
+            Assert.True(result.IsSuccess, result.Failure?.UserMessage);
+            Assert.NotNull(result.Value);
+            Assert.True(result.Value!.TargetSizeReached);
+            Assert.False(result.Value.ExceededTarget);
+            Assert.Equal(sourceBytes, result.Value.Bytes);
+            Assert.Equal(File.ReadAllBytes(sourcePath), File.ReadAllBytes(outPath));
         }
         finally
         {
@@ -115,14 +160,16 @@ public sealed class PngCompressionTests
         Directory.CreateDirectory(tempDir);
         try
         {
-            var sourcePath = CreateGradientPng(tempDir, 64, 64);
+            var sourcePath = Path.Combine(AppContext.BaseDirectory, "assets", "transparent.png");
+            Assert.True(File.Exists(sourcePath), $"Missing test asset: {sourcePath}");
             var sourceBytes = new FileInfo(sourcePath).Length;
             var outPath = Path.Combine(tempDir, "out_noop.png");
 
             var codec = new WicImageCodec();
             var req = new ImageEncodeRequest(
                 sourcePath, outPath, ImageFormat.Png, ImageFormat.Png,
-                new ImageTransformOptions(),
+                new ImageTransformOptions(
+                    Background: new ImageBackgroundOptions(true, "#FFFFFF")),
                 new ImageEncodingOptions(ImageOutputFormat.Png, Quality: 100),
                 ImageSafetyLimits.Default);
 
@@ -131,6 +178,7 @@ public sealed class PngCompressionTests
 
             var outBytes = new FileInfo(outPath).Length;
             Assert.True(outBytes <= sourceBytes, $"Output bytes ({outBytes}) must not exceed source bytes ({sourceBytes})");
+            Assert.Equal(File.ReadAllBytes(sourcePath), File.ReadAllBytes(outPath));
         }
         finally
         {
@@ -157,6 +205,9 @@ public sealed class PngCompressionTests
 
             var res = await codec.TransformAndEncodeAsync(req, CancellationToken.None);
             Assert.True(res.IsSuccess);
+            Assert.NotEqual(
+                Convert.ToBase64String(File.ReadAllBytes(sourcePath)),
+                Convert.ToBase64String(File.ReadAllBytes(outPath)));
 
             using var dstImg = new MagickImage(outPath);
             Assert.Equal((uint)100, dstImg.Width);
@@ -188,14 +239,13 @@ public sealed class PngCompressionTests
                 ImageSafetyLimits.Default);
 
             var res = await codec.TransformAndEncodeAsync(req, CancellationToken.None);
-            if (res.IsSuccess)
-            {
-                var outBytes = new FileInfo(outPath).Length;
-                Assert.True(outBytes <= targetBytes);
-                Assert.Equal(80, res.Value!.Metadata.Width);
-                Assert.Equal(80, res.Value!.Metadata.Height);
-                Assert.False(res.Value!.TargetSizeResized);
-            }
+            Assert.True(res.IsSuccess, res.Failure?.UserMessage);
+            Assert.NotNull(res.Value);
+            var outBytes = new FileInfo(outPath).Length;
+            Assert.True(outBytes <= targetBytes);
+            Assert.Equal(80, res.Value!.Metadata.Width);
+            Assert.Equal(80, res.Value.Metadata.Height);
+            Assert.False(res.Value.TargetSizeResized);
         }
         finally
         {
@@ -287,13 +337,12 @@ public sealed class PngCompressionTests
                 ImageSafetyLimits.Default);
 
             var res = await codec.TransformAndEncodeAsync(req, CancellationToken.None);
-            if (res.IsSuccess)
-            {
-                Assert.True(res.Value!.TargetSizeResized);
-                Assert.True(res.Value!.Metadata.Width < 200);
-                Assert.True(res.Value!.Metadata.Height < 200);
-                Assert.NotNull(res.Value!.TargetSizeNotice);
-            }
+            Assert.True(res.IsSuccess, res.Failure?.UserMessage);
+            Assert.NotNull(res.Value);
+            Assert.True(res.Value!.TargetSizeResized);
+            Assert.True(res.Value.Metadata.Width < 200);
+            Assert.True(res.Value.Metadata.Height < 200);
+            Assert.NotNull(res.Value.TargetSizeNotice);
         }
         finally
         {

--- a/tests/NanoPic.Codecs.Tests/PngQuantizerTests.cs
+++ b/tests/NanoPic.Codecs.Tests/PngQuantizerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Windows;
@@ -150,6 +151,25 @@ public sealed class PngQuantizerTests
     }
 
     [Fact]
+    public void Q5b_Quality100_Stops_ExactColor_Tracking_After_257_Colors()
+    {
+        var bitmap = CreateTestBitmap(512, 512, 96, (buf, offset, x, y) =>
+        {
+            var colorId = y * 512 + x;
+            buf[offset] = (byte)(colorId & 0xFF);
+            buf[offset + 1] = (byte)((colorId >> 8) & 0xFF);
+            buf[offset + 2] = (byte)((colorId >> 16) & 0xFF);
+            buf[offset + 3] = 255;
+        });
+
+        var quantized = PngQuantizer.Quantize(bitmap, 100, CancellationToken.None, out var info);
+
+        Assert.False(info.WasLossy);
+        Assert.Equal(257, info.UniqueColorCount);
+        Assert.Equal(PixelFormats.Bgra32, quantized.Format);
+    }
+
+    [Fact]
     public void Q6_TransparentPixels_Preserved()
     {
         // 包含左半纯透明、右半彩色的图像
@@ -187,18 +207,31 @@ public sealed class PngQuantizerTests
     [Fact]
     public void Q7_TranslucentGradient_AlphaPreserved()
     {
-        // 半透明渐变
+        // 半透明渐变，同时让 RGB 随 y 变化以强制进入 >256 色量化路径。
         var bitmap = CreateTestBitmap(32, 32, 96, (buf, offset, x, y) =>
         {
-            buf[offset] = 50;
-            buf[offset + 1] = 100;
-            buf[offset + 2] = 150;
+            buf[offset] = (byte)(y * 8);
+            buf[offset + 1] = (byte)(100 + y * 3);
+            buf[offset + 2] = (byte)(150 - y * 3);
             buf[offset + 3] = (byte)(x * 8); // Alpha 从 0 到 248
         });
 
         var quantized = PngQuantizer.Quantize(bitmap, 80, CancellationToken.None, out var info);
         Assert.NotNull(quantized.Palette);
         Assert.True(quantized.Palette.Colors.Count >= 2);
+
+        var converted = new FormatConvertedBitmap(quantized, PixelFormats.Bgra32, null, 0);
+        var output = new byte[32 * 32 * 4];
+        converted.CopyPixels(output, 32 * 4, 0);
+        Assert.Equal(0, output[3]);
+        Assert.InRange(output[(31 * 4) + 3], 220, 255);
+
+        var distinctAlpha = new HashSet<byte>();
+        for (var x = 0; x < 32; x++)
+        {
+            distinctAlpha.Add(output[(x * 4) + 3]);
+        }
+        Assert.True(distinctAlpha.Count >= 8, $"Expected an alpha gradient, got {distinctAlpha.Count} levels.");
     }
 
     [Fact]

--- a/tests/NanoPic.Codecs.Tests/PngTargetSizeSearchTests.cs
+++ b/tests/NanoPic.Codecs.Tests/PngTargetSizeSearchTests.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using NanoPic.Codecs;
+using NanoPic.Core;
+using Xunit;
+
+namespace NanoPic.Codecs.Tests;
+
+public sealed class PngTargetSizeSearchTests
+{
+    [Fact]
+    public async Task Search_Evaluates_MinQuality_When_Only_Q1_Reaches_Target()
+    {
+        var evaluated = new List<int>();
+        var result = await SearchAsync(
+            new TargetSizeOptions(
+                TargetBytes: 600,
+                AllowExceed: false,
+                MinQuality: 1,
+                MaxQuality: 100,
+                AllowResizeForTarget: false),
+            quality =>
+            {
+                evaluated.Add(quality);
+                return quality == 1 ? 500L : 1_000L;
+            });
+
+        Assert.True(result.IsSuccess, result.Failure?.UserMessage);
+        Assert.NotNull(result.Value);
+        Assert.Equal(1, result.Value!.Selected.Quality);
+        Assert.Contains(1, evaluated);
+    }
+
+    [Fact]
+    public async Task Search_Evaluates_Exact_MaxQuality_Boundary()
+    {
+        var evaluated = new List<int>();
+        var result = await SearchAsync(
+            new TargetSizeOptions(
+                TargetBytes: 600,
+                AllowExceed: false,
+                MinQuality: 1,
+                MaxQuality: 99,
+                AllowResizeForTarget: false),
+            quality =>
+            {
+                evaluated.Add(quality);
+                return quality == 99 ? 500L : 1_000L;
+            });
+
+        Assert.True(result.IsSuccess, result.Failure?.UserMessage);
+        Assert.NotNull(result.Value);
+        Assert.Equal(99, result.Value!.Selected.Quality);
+        Assert.Contains(99, evaluated);
+    }
+
+    [Fact]
+    public async Task Search_Encodes_Each_Size_And_Quality_At_Most_Once()
+    {
+        var counts = new Dictionary<int, int>();
+        var result = await SearchAsync(
+            new TargetSizeOptions(
+                TargetBytes: 600,
+                AllowExceed: false,
+                MinQuality: 1,
+                MaxQuality: 100,
+                AllowResizeForTarget: false),
+            quality =>
+            {
+                counts.TryGetValue(quality, out var count);
+                counts[quality] = count + 1;
+                return quality <= 80 ? 500L : 1_000L;
+            });
+
+        Assert.True(result.IsSuccess, result.Failure?.UserMessage);
+        Assert.NotEmpty(counts);
+        Assert.All(counts.Values, count => Assert.Equal(1, count));
+    }
+
+    [Fact]
+    public async Task Search_Refines_To_Highest_Quality_That_Reaches_Target()
+    {
+        var result = await SearchAsync(
+            new TargetSizeOptions(
+                TargetBytes: 600,
+                AllowExceed: false,
+                MinQuality: 1,
+                MaxQuality: 100,
+                AllowResizeForTarget: false),
+            quality => quality <= 82 ? 500L : 1_000L);
+
+        Assert.True(result.IsSuccess, result.Failure?.UserMessage);
+        Assert.NotNull(result.Value);
+        Assert.Equal(82, result.Value!.Selected.Quality);
+    }
+
+    [Theory]
+    [InlineData(0, 1, 100)]
+    [InlineData(100, 0, 100)]
+    [InlineData(100, 1, 101)]
+    [InlineData(100, 80, 40)]
+    public async Task Search_Rejects_Invalid_Target_Options(long targetBytes, int minQuality, int maxQuality)
+    {
+        var result = await SearchAsync(
+            new TargetSizeOptions(
+                TargetBytes: targetBytes,
+                AllowExceed: false,
+                MinQuality: minQuality,
+                MaxQuality: maxQuality,
+                AllowResizeForTarget: false),
+            _ => 500L);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ImageFailureKind.InvalidConfiguration, result.Failure?.Kind);
+    }
+
+    private static Task<ImageOperationResult<PngTargetSearchResult>> SearchAsync(
+        TargetSizeOptions options,
+        Func<int, long> sizeForQuality)
+    {
+        var frames = new[] { CreateFrame() };
+        return PngTargetSizeSearch.SearchAsync(
+            frames,
+            "unused.png",
+            options,
+            (_, _, quality, _) => Task.FromResult(sizeForQuality(quality)),
+            (currentFrames, _) => currentFrames,
+            CancellationToken.None);
+    }
+
+    private static BitmapFrame CreateFrame()
+    {
+        var pixels = new byte[] { 0, 0, 0, 255 };
+        var source = BitmapSource.Create(
+            1,
+            1,
+            96,
+            96,
+            PixelFormats.Bgra32,
+            null,
+            pixels,
+            4);
+        source.Freeze();
+        var frame = BitmapFrame.Create(source);
+        frame.Freeze();
+        return frame;
+    }
+}

--- a/tests/NanoPic.Codecs.Tests/WicImageCodecDpiTests.cs
+++ b/tests/NanoPic.Codecs.Tests/WicImageCodecDpiTests.cs
@@ -224,7 +224,11 @@ public sealed class WicImageCodecDpiTests
         converted.CopyPixels(pixels, checked(converted.PixelWidth * 4), 0);
         var counts = new System.Collections.Generic.Dictionary<string, int>
         {
-            ["TL"] = 0, ["TR"] = 0, ["BL"] = 0, ["BR"] = 0, ["C"] = 0
+            ["TL"] = 0,
+            ["TR"] = 0,
+            ["BL"] = 0,
+            ["BR"] = 0,
+            ["C"] = 0
         };
         for (var y = 0; y < converted.PixelHeight; y++)
         {

--- a/tests/NanoPic.Codecs.Tests/packages.lock.json
+++ b/tests/NanoPic.Codecs.Tests/packages.lock.json
@@ -128,7 +128,7 @@
       "nanopic.codecs": {
         "type": "Project",
         "dependencies": {
-          "NanoPic.Core": "[3.0.0-preview.1, )"
+          "NanoPic.Core": "[3.2.2, )"
         }
       },
       "nanopic.core": {

--- a/tests/NanoPic.DifferentialTests/packages.lock.json
+++ b/tests/NanoPic.DifferentialTests/packages.lock.json
@@ -184,7 +184,7 @@
       "nanopic.codecs": {
         "type": "Project",
         "dependencies": {
-          "NanoPic.Core": "[3.0.0-preview.1, )"
+          "NanoPic.Core": "[3.2.2, )"
         }
       },
       "nanopic.core": {
@@ -193,7 +193,7 @@
       "nanopic.infrastructure": {
         "type": "Project",
         "dependencies": {
-          "NanoPic.Core": "[3.0.0-preview.1, )",
+          "NanoPic.Core": "[3.2.2, )",
           "System.Text.Json": "[8.0.5, )"
         }
       },

--- a/tests/NanoPic.IntegrationTests/PngCompressionIntegrationTests.cs
+++ b/tests/NanoPic.IntegrationTests/PngCompressionIntegrationTests.cs
@@ -143,13 +143,56 @@ public sealed class PngCompressionIntegrationTests
                 OutputConflictPolicy.Overwrite);
 
             var result = await service.ProcessAsync(request, CancellationToken.None);
+            Assert.True(result.IsSuccess, result.Failure?.UserMessage);
+            Assert.NotNull(result.Value);
+            Assert.True(result.Value!.TargetSizeResized);
+            Assert.True(result.Value.Output!.Metadata.Width < 200);
+            Assert.NotNull(result.Value.TargetSizeNotice);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true);
+        }
+    }
 
-            if (result.IsSuccess)
+    [Fact]
+    public async Task Ui_Settings_Mapping_Preserves_NoOp_Png_When_Reencode_Would_Grow()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "nanopic-ui-noop-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var sourcePath = Path.Combine(AppContext.BaseDirectory, "assets", "transparent.png");
+            Assert.True(File.Exists(sourcePath), $"Missing test asset: {sourcePath}");
+            var destinationPath = Path.Combine(tempDir, "ui-output.png");
+            var sourceBytes = new FileInfo(sourcePath).Length;
+            var settings = NanoPicSettings.Default with
             {
-                Assert.True(result.Value!.TargetSizeResized);
-                Assert.True(result.Value!.Output!.Metadata.Width < 200);
-                Assert.NotNull(result.Value!.TargetSizeNotice);
-            }
+                Compress = NanoPicSettings.Default.Compress with
+                {
+                    OutputFormat = ImageOutputFormat.Png,
+                    Quality = 90,
+                    UseTargetSize = false
+                }
+            };
+            var options = ImageProcessingOptionsMapper.FromSettings(settings);
+            Assert.True(options.Transform.Background?.FlattenTransparency);
+
+            var service = new ImageFileProcessingService(new WicImageCodec());
+            var result = await service.ProcessAsync(
+                new ImageFileProcessRequest(
+                    sourcePath,
+                    destinationPath,
+                    options.Encoding,
+                    options.Transform,
+                    ImageSafetyLimits.Default,
+                    OutputConflictPolicy.Overwrite),
+                CancellationToken.None);
+
+            Assert.True(result.IsSuccess, result.Failure?.UserMessage);
+            Assert.NotNull(result.Value?.Output);
+            Assert.Equal(sourceBytes, result.Value!.Output!.Bytes);
+            Assert.Equal(File.ReadAllBytes(sourcePath), File.ReadAllBytes(destinationPath));
         }
         finally
         {

--- a/tests/NanoPic.IntegrationTests/RealWorldBenchmarkTests.cs
+++ b/tests/NanoPic.IntegrationTests/RealWorldBenchmarkTests.cs
@@ -237,7 +237,7 @@ public sealed class RealWorldBenchmarkTests
             // 测试场景 5：透明度通道（Alpha Channel）保真度测试
             // -------------------------------------------------------------
             reportSb.AppendLine("## 场景 5：透明通道 (Alpha Channel) 渐变保真度");
-            reportSb.AppendLine("验证：半透明圆形图标在量化压缩后，透明度渐变与透明背景完好无损保留。");
+            reportSb.AppendLine("验证：半透明圆形图标在量化压缩后仍保留 Alpha 通道；渐变级别由专项量化回归测试覆盖。");
             reportSb.AppendLine();
             reportSb.AppendLine("| 图标原大小 | 压缩后大小 | 体积减小 | 透明通道状态 | 输出格式 |");
             reportSb.AppendLine("|---|---|---|---|---|");
@@ -298,7 +298,7 @@ public sealed class RealWorldBenchmarkTests
 
             reportSb.AppendLine();
             reportSb.AppendLine("---");
-            reportSb.AppendLine("**实机测试结论**: 全部 6 组测试场景均 100% 成功通过，功能符合预期！");
+            reportSb.AppendLine("**实机测试结论**: 本报告中的 6 组自动化断言全部通过。");
 
             _output.WriteLine(reportSb.ToString());
             var artifactDir = Environment.GetEnvironmentVariable("NANOPIC_REPORT_DIR");

--- a/tests/NanoPic.IntegrationTests/packages.lock.json
+++ b/tests/NanoPic.IntegrationTests/packages.lock.json
@@ -184,7 +184,7 @@
       "nanopic.codecs": {
         "type": "Project",
         "dependencies": {
-          "NanoPic.Core": "[3.0.0-preview.1, )"
+          "NanoPic.Core": "[3.2.2, )"
         }
       },
       "nanopic.core": {
@@ -193,7 +193,7 @@
       "nanopic.infrastructure": {
         "type": "Project",
         "dependencies": {
-          "NanoPic.Core": "[3.0.0-preview.1, )",
+          "NanoPic.Core": "[3.2.2, )",
           "System.Text.Json": "[8.0.5, )"
         }
       },


### PR DESCRIPTION
## Summary

- fix PNG source reuse when UI-equivalent background options are semantically inactive
- fix target-size search boundaries, candidate reuse, and already-satisfied targets
- bound Q100 high-color memory growth and strengthen regression coverage
- upgrade Costura/Fody to remove the vulnerable legacy dependency chain
- complete CI audit artifacts, SBOM, licenses, and third-party notices

## Validation

- Release build: 0 warnings, 0 errors
- Tests: 236 passed
- NuGet vulnerabilities: 0
- NanoPic.exe: 1,322,496 bytes (< 2 MB)
- Branch CI: success